### PR TITLE
Initial Windows support

### DIFF
--- a/beachmsg.js
+++ b/beachmsg.js
@@ -26,7 +26,14 @@ if (!fs.existsSync(commandFilePath)) {
 }
 
 // Send command and args
-const client = connect(SOCKET_PATH, () => {
+let endpoint;
+if (process.platform !== "win32") {
+  const DATA_DIR = process.env.XDG_DATA_HOME || path.join(process.env.HOME, ".local/share");
+  endpoint = `${DATA_DIR}/beachpatrol/beachpatrol.sock`;
+} else {
+  endpoint = String.raw`\\.\pipe\beachpatrol`;
+}
+const client = connect(endpoint, () => {
   client.write([commandName, ...args].join(' ')); 
 });
 

--- a/beachmsg.js
+++ b/beachmsg.js
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { URL } from 'url';
 
-const DATA_DIR = process.env.XDG_DATA_HOME || path.join(HOME_DIR, '.local/share');
+const DATA_DIR = process.env.XDG_DATA_HOME || path.join(process.env.HOME, '.local/share');
 const SOCKET_PATH = `${DATA_DIR}/beachpatrol/beachpatrol.sock`;
 
 // if there are no arguments, bail out
@@ -19,7 +19,7 @@ const [,, commandName, ...args] = process.argv;
 // Check if command script exists
 const COMMANDS_DIR = 'commands';
 const projectRoot = new URL('.', import.meta.url).pathname;
-const commandFilePath = path.join(projectRoot, COMMANDS_DIR, `${commandName}.js`);
+const commandFilePath = path.join(projectRoot, COMMANDS_DIR, `${commandName}.js`).replace(/^\\/, '');
 if (!fs.existsSync(commandFilePath)) {
   console.error(`Error: Command script ${commandName}.js does not exist.`);
   process.exit(1);

--- a/beachpatrol.js
+++ b/beachpatrol.js
@@ -197,7 +197,7 @@ const server = createServer((socket) => {
     const [commandName, ...args] = message;
     const COMMANDS_DIR = 'commands';
     const projectRoot = new URL('.', import.meta.url).pathname;
-    const commandFilePath = path.join(projectRoot, COMMANDS_DIR, `${commandName}.js`);
+    const commandFilePath = path.join(projectRoot, COMMANDS_DIR, `${commandName}.js`).replace(/^\\/, '');
 
     // log command
     console.log(`Received command: ${commandName} ${args.join(' ')}`);
@@ -212,7 +212,7 @@ const server = createServer((socket) => {
       try {
         // import with a timestamp to avoid caching
         const modulePath = path.resolve(commandFilePath);
-        const {default: command} = await import(`${modulePath}?t=${Date.now()}`);
+        const {default: command} = await import(`file://${modulePath}?t=${Date.now()}`);
 
         await command(browserContext, ...args);
         const SUCCESS_MESSAGE = 'Command executed successfully.';


### PR DESCRIPTION
I'm sharing the tweaks I did to make `beachpatrol` and `beachmsg` work on both Windows and Ubuntu on WSL. I tried to change the scripts as little as possible, while also maintaining readability and consistency.

The project almost worked as is, except for the annoying fact that Node doesn't seem to support Unix Domain Sockets on Windows, so that had to be special-cased to use named pipes :)

And there were the usual path string oddities, whose solutions I'm explaining via comments in this PR to share you what I found out.

As for install instructions, I found that `npm install -g .` works well as an alternative for `sudo make install` on the platforms I tested.