### PR TITLE
Fix argument parsing to support spaces and special characters in command arguments

### DIFF
--- a/beachmsg.js
+++ b/beachmsg.js
@@ -46,7 +46,7 @@ if (process.platform !== "win32") {
   endpoint = String.raw`\\.\pipe\beachpatrol`;
 }
 const client = connect(endpoint, () => {
-  client.write([commandName, ...args].join(' ')); 
+  client.write(JSON.stringify([commandName, ...args])); 
 });
 
 client.on('data', (data) => {

--- a/beachpatrol.js
+++ b/beachpatrol.js
@@ -193,7 +193,12 @@ if (usingUnixDomainSocket) {
 // Listen for commands
 const server = createServer((socket) => {
   socket.on('data', async (data) => {
-    const message = data.toString().trim().split(' '); // Splitting message into parts
+    let message;
+    try {
+      message = JSON.parse(data.toString());
+    } catch (e) {
+      message = data.toString().trim().split(' ');
+    }
     const [commandName, ...args] = message;
 
     // Sanitize commandName


### PR DESCRIPTION
**Description:**
This patch improves the way command arguments are transmitted from beachmsg.js (client) to beachpatrol.js (server). Previously, arguments containing spaces (e.g., 'Hello, world!') were split into multiple arguments, causing issues with commands that require multi-word or special character arguments.

**Key changes:**
* Arguments are now serialized using JSON.stringify in beachmsg.js before being sent to the server.
* On the server side (beachpatrol.js), arguments are parsed using JSON.parse. If parsing fails (for backward compatibility), the code falls back to the previous split(' ') method.
* This ensures that arguments with spaces, quotes, or special characters are transmitted and parsed correctly as a single argument.

**Example usage (before and after):**
```
# Before this patch, the following command:
beachmsg some-command 'Hello, world!'

# would result in the arguments being split as:
# ['Hello,', 'world!']

# After this patch, the same command:
beachmsg some-command 'Hello, world!'

# will correctly parse the arguments as:
# ['Hello, world!']
```

**Motivation:**
This change allows users to pass arguments containing spaces and special characters without issues, improving the usability and robustness of the command interface.

**Testing:**
* Verified that commands with multi-word arguments (e.g., 'Hello, world!') are now received as a single argument.
* Backward compatibility is maintained for older clients.
