### PR TITLE
Add active page detection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Suppose you want to automate web search. You can create a `commands/search.js`
 file (relative to the cloned repo directory) with the following content:
 
 ```javascript
-export default async (context, ...searchTerms) => {
+export default async ({ context, activePage }, ...searchTerms) => {
   const page = await context.newPage();
   await page.goto(
     `https://www.google.com/search?q=${encodeURIComponent(searchTerms.join(" "))}`,
@@ -99,11 +99,12 @@ Every Beachpatrol command must export a default async function, which is the
 entry point of your command.
 
 The function should take:
-- The Playwright browser context as its first argument, and
-- the arguments to the command, if any.
+- An object containing `{ context, activePage }` as its first argument, where:
+  - `context` is the Playwright [BrowserContext](https://playwright.dev/docs/api/class-browsercontext)
+  - `activePage` is the currently focused [Page](https://playwright.dev/docs/api/class-page) object, or `null`
+- The arguments to the command, if any.
 
-Then, you simply automate the browser by interacting with the [BrowserContext
-API](https://playwright.dev/docs/api/class-browsercontext).
+Then, you simply automate the browser by interacting with the Playwright API.
 
 The `search.js` command above opens a new tab (`context.newPage()`), performs
 the task, and leaves it focused. Other possible commands might work on the
@@ -322,6 +323,9 @@ This project is in **alpha**.
   Chromium. Firefox has slightly less advanced plugins currently, so users
   might encounter some issues such as Cloudflare's false positives, and extra
   Google captchas.
+- Active page detection (tracking which tab is currently focused) only works
+  with Chromium. Firefox support is planned for a future browser extension
+  release. For now, `activePage` will always be `null` when using Firefox.
 
 ## You might also like
 

--- a/commands/smoke-test.js
+++ b/commands/smoke-test.js
@@ -1,4 +1,4 @@
-// Peform the classic Selenium smoke test, as described in:
+// Perform the classic Selenium smoke test, as described in:
 // https://github.com/SeleniumHQ/seleniumhq.github.io/blob/trunk/examples/javascript/test/getting_started/firstScript.spec.js
 
 // Counteracts some websites, for example bootstrap ones, which have smooth scrolling.
@@ -10,11 +10,11 @@ const forceInstantScroll = async (page) => {
 };
 
 // Every beachpatrol command must export a default async function which takes:
-//   - The Playwright browser context as its first argument, and
+//   - An object with { context, activePage } as its first argument, and
 //   - the arguments to the command.
 // Then, you simply automate the browser by interacting with the BrowserContext API.
 //   - Docs: https://playwright.dev/docs/api/class-browsercontext
-export default async (context, ...args) => {
+export default async ({ context, activePage }, ...args) => {
   const page = await context.newPage();
   await page.goto("https://www.selenium.dev/selenium/web/web-form.html");
 

--- a/playwright-active-page-extension/README.md
+++ b/playwright-active-page-extension/README.md
@@ -1,0 +1,91 @@
+# Playwright Active Page Extension
+
+A browser extension that reports the active page to Playwright via network
+interception.
+
+## Overview
+
+Playwright doesn't provide an API to detect which browser tab is currently
+active/focused. All pages are treated equally, making it impossible to know
+which tab the user is interacting with.
+
+- Source: https://github.com/microsoft/playwright/issues/3570
+
+This extension:
+1. Detects when a tab becomes active (via browser APIs)
+2. Makes a fake `fetch()` request to `https://playwright-active-page`
+3. Playwright should then intercept this request with `page.route()`
+4. The route handler knows which page sent the request = the active page!
+
+This approach is:
+- Cross-browser (Chromium and Firefox with proper setup)
+  - Indeed, the `manifest.json` follows best cross-browser practices as per
+    [Firefox Manifest V3
+    Docs](https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/)
+- No CSP issues (fetch requests aren't blocked from extensions)
+
+**Note:** The following example uses Chromium. For full firefox support, you
+would need to use a more advanced setup to load the extension, as Firefox
+extension are not natively supported in Playwright.
+- Sources:
+  - https://playwright.dev/docs/chrome-extensions
+  - https://github.com/ueokande/playwright-webextext
+
+**Note:** This extension is part of the
+[beachpatrol](https://github.com/sebastiancarlos/beachpatrol) project, but has
+no external dependencies. You can use it standalone with any Playwright
+project.
+
+## Example
+
+```javascript
+#!/usr/bin/env node
+import { chromium } from 'playwright'; // or 'patchright'
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+// Track the active page
+let activePage = null;
+
+// Launch Chromium with the extension
+// - This assumes the extension folder is located on the same level as this script
+const extensionPath = path.join(SCRIPT_DIR, 'playwright-active-page-extension');
+const context = await chromium.launchPersistentContext('', {
+  headless: false,
+  args: [
+    `--disable-extensions-except=${extensionPath}`,
+    `--load-extension=${extensionPath}`
+  ]
+});
+
+// Setup route handler for each page
+async function setupPage(page) {
+  await page.route('https://playwright-active-page', async (route) => {
+    // This page became active!
+    activePage = page;
+    console.log(`Active page: ${page.url()}`);
+
+    // Fulfill the request
+    await route.fulfill({ status: 200 });
+  });
+}
+
+// Setup existing and new pages
+for (const page of context.pages()) {
+  await setupPage(page);
+}
+context.on('page', setupPage);
+
+// Create test pages
+await context.newPage().then(p => p.goto('https://example.com'));
+await context.newPage().then(p => p.goto('https://github.com'));
+await context.newPage().then(p => p.goto('https://google.com'));
+
+console.log('Switch tabs manually to see detection working!');
+console.log(`Current active page: ${activePage?.url() || 'none'}`);
+
+// Keep browser open
+await new Promise(() => {});
+```

--- a/playwright-active-page-extension/background.js
+++ b/playwright-active-page-extension/background.js
@@ -1,0 +1,29 @@
+/**
+ * Non-persistent service worker (or "background script", on Firefox parlance) for Playwright Active
+ * Page Extension.
+ *
+ * - Listens for tab activation and navigation events, and messages the extension's content script
+ *   for the corresponding tab.
+ *   - It then forwards it to Playwright to keep track of the active page.
+ * - Works on both Chrome and Firefox.
+ *   - Note that it uses the 'chrome' API even in Firefox, which provides compatibility.
+ *   - Manifest v3 compatible.
+ */
+
+// Helper function to send message notifying active page.
+function sendMessageToActiveTab(tabId) {
+  chrome.tabs.sendMessage(tabId, { type: "PLAYWRIGHT_PAGE_ACTIVATED" });
+}
+
+// Listing for tab activation.
+chrome.tabs.onActivated.addListener(async ({ tabId }) => {
+  sendMessageToActiveTab(tabId);
+});
+
+// Listen for navigation completion in the active tab.
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  // We only care when the page has finished loading and the tab is active.
+  if (changeInfo.status === "complete" && tab.active) {
+    sendMessageToActiveTab(tabId);
+  }
+});

--- a/playwright-active-page-extension/contentScript.js
+++ b/playwright-active-page-extension/contentScript.js
@@ -1,0 +1,20 @@
+/**
+ * Content Script for Playwright Active Page Extension
+ *
+ * - Listens for "active page" messages from the extension's service worker.
+ * - Notifies Playwright when the page becomes active via a fake fetch request.
+ * - Works on both Chrome and Firefox.
+ *   - Note that it uses the 'chrome' API even in Firefox, which provides compatibility.
+ *   - Manifest v3 compatible.
+ */
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === "PLAYWRIGHT_PAGE_ACTIVATED") {
+    // Use fetch to signal page activation - this will be intercepted by Playwright
+    // Using a fake internal URL that we'll intercept with page.route()
+    // Use HTTPS to avoid mixed content blocking on HTTPS pages
+    fetch("https://playwright-active-page").catch(() => {
+      // Ignore errors. The request should be intercepted successfully anyway.
+    });
+  }
+});

--- a/playwright-active-page-extension/manifest.json
+++ b/playwright-active-page-extension/manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 3,
+  "name": "Playwright Active Page Extension",
+  "version": "0.0.6",
+  "description": "Reports the browser's active page to Playwright via network interception.",
+  "homepage_url": "https://github.com/sebastiancarlos/beachpatrol",
+  "incognito": "spanning",
+  "permissions": ["tabs"],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "playwright-active-page-extension@sebastiancarlos.github.io",
+      "strict_min_version": "109.0"
+    }
+  },
+  "background": {
+    "service_worker": "background.js",
+    "scripts": ["background.js"],
+    "type": "module",
+    "persistent": false
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.js"]
+    }
+  ]
+}


### PR DESCRIPTION
Playwright treats all tabs as active and provides no API to detect which browser tab is currently focused. This makes it impossible for commands to know which page the user is interacting with.
- Source: https://github.com/microsoft/playwright/issues/3570

To work around this, we've added a tiny browser extension that:
1. Detects when a tab becomes active (via browser APIs)
2. Makes a fake fetch request to https://playwright-active-page
3. Gets intercepted by page.route() in beachpatrol.js (a network request never happens)
4. The route handler knows which page sent the request, which is then tracked as the active page!

**BREAKING CHANGE:** Commands now receive `{ context, activePage }` as their first argument, where `activePage` is the currently focused Playwright Page object (or null).

Yes, this is very hacky, but it's the best possible solution given the constraints. This approach also bypasses Patchright's console/evaluate limitations, which would have been the preferred method but are intentionally disabled for stealth purposes.
- Source: https://github.com/Kaliiiiiiiiii-Vinyzu/patchright/issues/30

The extension (`playwright-active-page-extension`) is generic enough to be used standalone with any Playwright project and includes full documentation.

Note: Active page detection currently only works with Chromium/Patchright. Firefox support is planned for a future full-fledged browser extension that can be installed from Mozilla Add-ons.